### PR TITLE
update Info.plist with bluetooth privacy description

### DIFF
--- a/Basic Chat/Info.plist
+++ b/Basic Chat/Info.plist
@@ -39,5 +39,7 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+        <string>I neeeeeeed bluetooth to work</string>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes this error when running with iOS's additional permission notification requirements:
```
2020-10-20 18:36:49.983589-0500 Basic Chat[10287:2615802] [access] This app has crashed because it attempted to access privacy-sensitive data without a usage description.  The app's Info.plist must contain an NSBluetoothAlwaysUsageDescription key with a string value explaining to the user how the app uses this data.```